### PR TITLE
Add snippet to README about incsearch.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ Alternatively you can just drop the `plugin` and `doc` folders into your
 `~/.vim` directory. Don't forget to run `:helptags ~/.vim/doc` to generate the
 help tags after a manual installation.
 
+If you are using [incsearch.vim](https://github.com/haya14busa/incsearch.vim)
+and you'd like `vim-searchant` to play-nicely, you can add the following snippet
+to hide the searchant highlight:
+
+```vim
+" Disable Searchant highlight when incsearch.vim highlights also disable
+autocmd CursorMoved * call SearchantStop()
+function SearchantStop()
+  :execute "normal \<Plug>SearchantStop"
+endfunction
+```
+
+This assumes that you have `let g:incsearch#auto_nohlsearch = 1` in your config.
+
 ## License
 
 Copyright (C) 2017 Tim Schumacher


### PR DESCRIPTION
I ran into an issue using this plugin with `incsearch.vim` whereby the searchant highlight would remain after the incsearch highlights had been hidden. Had a dig around in incsearch code to find that hiding highlights [is triggered by an `CursorMove` autocommand](https://github.com/haya14busa/incsearch.vim/blob/25e2547fb0566460f5999024f7a0de7b3775201f/autoload/incsearch/autocmd.vim#L38). 

Assuming the vimmer has `let g:incsearch#auto_nohlsearch = 1` set in config, then the searchant highlight can easily be hidden when incsearch.vim highlights are hidden using a simple function:

```vim
" Disable Searchant highlight when incsearch.vim highlights also disable
autocmd CursorMoved * call SearchantStop()
function SearchantStop()
  :execute "normal \<Plug>SearchantStop"
endfunction
```

Let me know if I'm overlooking something here?

![2020-02-24 15 54 24](https://user-images.githubusercontent.com/1472981/75126288-1d464000-571e-11ea-9cf0-fb6205f0f39c.gif)
