### PR TITLE
Ignore Vim helptags in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
Without this entry in the `.gitignore` file, the tree is shown as dirty as soon as the user generates helptags for this plugin (e.g. with `:helptags ALL`).

```
~/.vim/pack/ui/start/searchant heads/master*
❯ git status --short
?? doc/tags
```